### PR TITLE
Add example docker-compose.yml file and associated docs to readme. Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,22 @@ install sudo and confugure their sudoers file accordingly.
 
 Windows users do not need to do anything here.
 
-## Get this script, cd to it
+### Docker Compose
+
+You may choose to deploy using [`Docker Compose`](https://docs.docker.com/compose/).
+If you do, you will need to install the `docker-compose` command, which you can 
+learn about here: https://docs.docker.com/compose/install/#install-compose
+
+## Installing
+
+### Get this repo, cd to it
 
 ```
 git clone https://github.com/terminusdb/terminusdb-quickstart
 cd terminusdb-quickstart
 ```
 
-## Run the container (the first time)
+### Run the container by using the script (the first time)
 
 ```
 ./terminusdb-container run
@@ -74,7 +82,7 @@ d9fa4a1acf93: Pulling fs layer
 [ ... ]
 ```
 
-## If you've installed before 
+#### If you've installed before
 
 You may need to move or remove previous volumes or you may encounter bugs or
 the old console.
@@ -88,7 +96,14 @@ This will delete storage volume
 Are you sure? [y/N] y
 ```
 
-## Using the console
+#### Installing with Docker Compose
+
+Run `docker-compose up -d` in the `terminusdb-quickstart` repo to deploy the
+`terminusdb-server` container. Run `docker-compose down` to remove the container
+while preserving the named data volume, or `docker-compose down -v` to also
+destroy the data volume.
+
+### Using the console
 
 Ready to terminate? Open the TerminusDB Console in your web browser.
 
@@ -98,7 +113,7 @@ Ready to terminate? Open the TerminusDB Console in your web browser.
 
 Or go here: http://localhost:6363/console
 
-## To stop, attach, etc, see usage
+### To stop, attach, etc, see usage
 ```
 ./terminusdb-container 
 
@@ -180,7 +195,7 @@ follow these steps:
 1. Copy `ENV.example` to `ENV`.
 2. Edit `ENV`: uncomment the lines you want to change and set the values.
 
-## Examples
+## `ENV` Examples
 
 These are examples of environment variables you can set when running
 `./terminusdb-container`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ container.
 
 What the heck is TerminusDB? See here: https://terminusdb.com
 
+## Table of Contents
+
+* [Prerequisites](#Prerequisites)
+  * [Docker](#Docker)
+  * [Git](#Git)
+  * [Sudo](#Sudo)
+  * [Docker Compose](#Docker-Compose) (optional)
+* [Installing](#Installing)
+  * [Get the repo](#Get-this-repo-cd-to-it)
+  * [Run the container by using the script (the first time)](#Run-the-container-by-using-the-script-the-first-time)
+    * OR [Install when you have a previous installation](#If-youve-installed-before)
+    * OR [Installing with Docker Compose instead](#Installing-with-Docker-Compose)
+  * [Using the console](#Using-the-console)
+  * [To stop, attach, etc, see usage](#To-stop-attach-etc-see-usage)
+* [Using The Enviroment](#Using-The-Enviroment)
+  * [Security](#Security)
+  * [`ENV` File](#ENV-file)
+  * [`ENV` Examples](#ENV-Examples)
+
 ## Prerequisites
 
 ### Docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3"
+
+volumes:
+  terminusdb_storage:
+
+services:
+  terminusdb-server:
+    image: terminusdb/terminusdb-server:v2.0.4
+    container_name: terminusdb-server
+    hostname: terminusdb-server
+    ports:
+      - 6363:6363
+    environment:
+      - TERMINUSDB_SERVER_NAME=http://127.0.0.1
+      - TERMINUSDB_SERVER_PORT=6363
+
+      # There are multiple ways to configure TerminusDB security through
+      # environment variables. Several reasonable options are included below.
+      # Uncomment the option you decide on and comment out others.
+      # Don't forget to change the default password!
+
+      # Security Option 1 (default): Assumes TerminusDB is only accessible from
+      # the machine it's running on and all access to port 6363 is considered
+      # authorized.
+      - TERMINUSDB_HTTPS_ENABLED=false
+      - TERMINUSDB_AUTOLOGIN=true
+
+      # Security Option 2: TerminusDB is set up behind a TLS-terminating reverse
+      # proxy with admin authentication provided by password.
+      # - TERMINUSDB_HTTPS_ENABLED=false
+      # - TERMINUSDB_AUTOLOGIN=false
+      # - TERMINUSDB_PUBLIC_URL=https://example.com
+      # - TERMINUSDB_ADMIN_PASS=root  #  Change before exposing to the internet.
+
+      # Security Option 3: Terminate TLS in TerminusDB directly by providing ssl
+      # cert files manually, with admin authentication provided by password.
+      # See `volumes:` section to specify tls files to mount from your local system
+      # for TerminusDB to use to establish TLS sessions.
+      # - TERMINUSDB_HTTPS_ENABLED=true
+      # - TERMINUSDB_AUTOLOGIN=false
+      # - TERMINUSDB_PUBLIC_URL=https://example.com
+      # - TERMINUSDB_SSL_CERT=/etc/ssl/fullchain.pem     # This is the path inside the container
+      # - TERMINUSDB_SSL_CERT_KEY=/etc/ssl/privkey.pem
+      # - TERMINUSDB_ADMIN_PASS=root  #  Change before exposing to the internet.
+
+    # Volumes mounted to the container.
+    # Syntax is `[SOURCE:]TARGET[:MODE]` See: https://docs.docker.com/compose/compose-file/#volumes
+    # SOURCE: host filesystem path or volume name. TARGET: container filesystem path
+    volumes:
+      - terminusdb_storage:/app/terminusdb/storage:rw
+
+      # Security Option 3 (cont)
+      # - /etc/letsencrypt/live/example.com/fullchain.pem:/etc/ssl/fullchain.pem:ro
+      # - /etc/letsencrypt/live/example.com/privkey.pem:/etc/ssl/privkey.pem:ro


### PR DESCRIPTION
These changes add a `docker-compose.yml` file and associated documentation to the README, as per issue #5.

I wasn't sure how best to integrate the option of installing with `docker-compose` into the docs, so I ended up adding it after the "If you've installed before" section.  Then it was getting difficult to see the document structure so I added a Table of Contents and adjusted the headings to match, which seems to make it a bit better.

I added a few "reasonable" security configuration options and their explanations to the `docker-compose.yml` file, commented out to give someone a starting point if they desire one of these kinds of deployments.  "Security Option 1" (default, uncommented) is autologin, no security; "Security Option 2" is if you're behind a TLS reverse proxy with an admin password; "Security Option 3" is to handle TLS directly also with an admin password.  I currently use "Security Option 2" and briefly tested "Security Option 1", I did not try "Security Option 3".

One might ask of this PR:

* [ ] Is this a good spot for the (admittedly light) docker compose docs?
* [ ] Are the changes to the README structure ok?
* [ ] Is the addition of the ToC desired?
* [ ] Is the description and discussion of "Security Options" in `docker-compose.yml` good?
