### PR TITLE
Print usage for 'help' command.

### DIFF
--- a/terminusdb-container
+++ b/terminusdb-container
@@ -258,6 +258,9 @@ fi
 
 if [[ -n "$1" ]]; then
   case "$1" in
+    "help")
+      _usage
+    ;;
     "run")
       # _build
       version_check


### PR DESCRIPTION
The `terminusdb-container` script mentions a `help` command in it's usage string but running it prints `invalid command` (as well as the usage string). This change cleans the output up slightly by expecting a `help` command input.

```
./terminusdb-container help

invalid command

USAGE:
  terminusdb-container [COMMAND]

  help        show usage
  run         run container
  stop        stop container
  console     launch console in web browser
  attach      attach to prolog shell
  exec        execeute a command inside the container
  rm          remove volumes
```